### PR TITLE
README.md: Small formatting changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,30 +5,40 @@ Compute cyclomatic complexity of functions based on the gcc internal representat
 
 http://en.wikipedia.org/wiki/Cyclomatic_complexity
 
-The complexity M is then defined as:
+The complexity M is then defined as `M = E − N + 2P` where
 
-M = E − N + 2P
+    E = the number of edges of the graph
+    N = the number of nodes of the graph
+    P = the number of connected components (exit nodes).
 
-where
-
- E = the number of edges of the graph
-
- N = the number of nodes of the graph
-
- P = the number of connected components (exit nodes).
-
-Homepage:
+Homepage
+--------
 
 http://www.grsecurity.net/~ephox/
 
-Usage:
+Compiling & Usage
+-----------------
 
-$ # for 4.5/4.6/C based 4.7
+##### gcc 4.5 - 4.7 (C):
 
-$ gcc -I`gcc -print-file-name=plugin`/include -I`gcc -print-file-name=plugin`/include/c-family -fPIC -shared -O2 -o cyc_complexity_plugin.so cyc_complexity_plugin.c
+```shell
+$ gcc -I`gcc -print-file-name=plugin`/include \
+      -I`gcc -print-file-name=plugin`/include/c-family \
+      -fPIC -shared -O2 \
+      -o cyc_complexity_plugin.so cyc_complexity_plugin.c
+```
 
-$ # for C++ based 4.7/4.8+
+##### gcc 4.7 (C++) - 4.8+
 
-$ g++ -I`g++ -print-file-name=plugin`/include -I`g++ -print-file-name=plugin`/include/c-family -fPIC -shared -O2 -o cyc_complexity_plugin.so cyc_complexity_plugin.c
+```shell
+$ g++ -I`g++ -print-file-name=plugin`/include \
+      -I`g++ -print-file-name=plugin`/include/c-family \
+      -fPIC -shared -O2 \
+      -o cyc_complexity_plugin.so cyc_complexity_plugin.c
+```
 
+##### Usage
+
+```shell
 $ gcc -fplugin=./cyc_complexity_plugin.so test.c -O2
+```


### PR DESCRIPTION
To make the README visually a bit more pleasing, this patch reformats it a little:
- The complexity explanation was inlined and wrapped in code blocks
- Homepage and Usage were turned into headers
- The gcc/g++ command lines were broken up into multiple lines, and wrapped in a shell code block

Signed-off-by: Gergely Nagy algernon@balabit.hu
